### PR TITLE
remove unused Castle.Core.AsyncInterceptor package reference

### DIFF
--- a/AmbientTransaction/AmbientTransaction/AmbientTransaction.csproj
+++ b/AmbientTransaction/AmbientTransaction/AmbientTransaction.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
 	  <PackageReference Include="Architect.AmbientContexts" Version="2.0.1" />
-	  <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The Castle.Core.AsyncInterceptor package was not used anywhere in the codebase but was still referenced in the project file. Removing this dangling dependency to clean up the project.

Resolves #2

Generated with [Claude Code](https://claude.ai/code)